### PR TITLE
[FEAT] Swagger 반영을 위한 DTO, Controller 틀 생성

### DIFF
--- a/src/main/java/healeat/server/domain/enums/Veget.java
+++ b/src/main/java/healeat/server/domain/enums/Veget.java
@@ -1,9 +1,0 @@
-package healeat.server.domain.enums;
-
-public enum Veget {
-    FLEXI,
-    POLO_PESCET,
-    PESCET,
-    POLO,
-    VEGAN
-}

--- a/src/main/java/healeat/server/web/controller/HealthPlanController.java
+++ b/src/main/java/healeat/server/web/controller/HealthPlanController.java
@@ -2,6 +2,7 @@ package healeat.server.web.controller;
 
 import healeat.server.apiPayload.ApiResponse;
 import healeat.server.domain.HealthPlan;
+import healeat.server.domain.Member;
 import healeat.server.service.HealthPlanService;
 import healeat.server.converter.HealthPlanConverter;
 import healeat.server.web.dto.HealthPlanResponseDto;
@@ -9,6 +10,7 @@ import healeat.server.web.dto.HealthPlanRequestDto;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -28,7 +30,8 @@ public class HealthPlanController {
      */
     @Operation(summary = "건강 관리 목표 조회", description = "건강 관리 목표를 전체 조회합니다.")
     @GetMapping
-    public ApiResponse<HealthPlanResponseDto.HealthPlanListDto> getAllHealthPlans() {
+    public ApiResponse<HealthPlanResponseDto.HealthPlanListDto> getAllHealthPlans(
+            @AuthenticationPrincipal Member member) {
         List<HealthPlan> healthPlans = healthPlanService.getAllHealthPlans();
         List<HealthPlanResponseDto.HealthPlanOneDto> healthPlanDtoList = healthPlans.stream()
                 .map(healthPlanConverter::toHealthPlanOneDto)
@@ -46,7 +49,8 @@ public class HealthPlanController {
             "(이미지와 메모는 아직 추가되지 않았음)")
     @PostMapping
     public ApiResponse<HealthPlanResponseDto.setResultDto> createHealthPlan(
-            @RequestBody HealthPlanRequestDto.HealthPlanUpdateRequestDto request) {
+            @RequestBody HealthPlanRequestDto.HealthPlanUpdateRequestDto request,
+            @AuthenticationPrincipal Member member) {
         HealthPlan createdHealthPlan = healthPlanService.createHealthPlan(request);
 
         return ApiResponse.onSuccess(healthPlanConverter.toSetResultDto(createdHealthPlan));
@@ -59,6 +63,7 @@ public class HealthPlanController {
             "(이미지와 메모는 아직 추가되지 않았음)")
     @PatchMapping("/{planId}")
     public ApiResponse<HealthPlanResponseDto.HealthPlanOneDto> updateHealthPlanPartial(
+            @AuthenticationPrincipal Member member,
             @PathVariable Long planId,
             @RequestBody HealthPlanRequestDto.HealthPlanUpdateRequestDto updateRequest) {
         HealthPlan updatedHealthPlan = healthPlanService.updateHealthPlanPartial(planId, updateRequest);
@@ -71,7 +76,9 @@ public class HealthPlanController {
      */
     @Operation(summary = "건강 관리 목표 삭제", description = "건강 관리 목표를 삭제합니다.")
     @DeleteMapping("/{planId}")
-    public ApiResponse<HealthPlanResponseDto.deleteResultDto> deleteHealthPlan(@PathVariable Long planId) {
+    public ApiResponse<HealthPlanResponseDto.deleteResultDto> deleteHealthPlan(
+            @AuthenticationPrincipal Member member,
+            @PathVariable Long planId) {
         HealthPlan deleteHealthPlan = healthPlanService.getHealthPlanById(planId);
         HealthPlanResponseDto.deleteResultDto response = healthPlanConverter.toDeleteResultDto(deleteHealthPlan);
 

--- a/src/main/java/healeat/server/web/controller/HomeController.java
+++ b/src/main/java/healeat/server/web/controller/HomeController.java
@@ -1,0 +1,36 @@
+package healeat.server.web.controller;
+
+import healeat.server.apiPayload.ApiResponse;
+import healeat.server.domain.Member;
+import healeat.server.web.dto.StoreResonseDto;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/home")
+@RequiredArgsConstructor
+public class HomeController {
+
+    @GetMapping()
+    @Operation(summary = "홈화면에서 추천 가게 리스트를 조회합니다.",
+            description = "홈화면에서 현재 위치를 기반으로 추천 가게 리스트를 조회합니다.")
+    public ApiResponse<StoreResonseDto.StorePreviewDtoList> getHomeList(
+            @AuthenticationPrincipal Member member){
+
+        return ApiResponse.onSuccess(null);
+    }
+
+    @GetMapping("/{storeId}/preview")
+    @Operation(summary = "홈화면에서 추천 가게 미리보기를 조회합니다.",
+            description = "홈화면에서 현재 위치를 기반으로 추천된 가게 리스트 중 하나를 선택했을 때 보이는 미리보기 화면입니다.")
+    public ApiResponse<StoreResonseDto.HomeStorePreviewDto> getStorePreview(
+            @PathVariable Long storeId, @AuthenticationPrincipal Member member){
+
+        return ApiResponse.onSuccess(null);
+    }
+}

--- a/src/main/java/healeat/server/web/controller/MyPageController.java
+++ b/src/main/java/healeat/server/web/controller/MyPageController.java
@@ -1,0 +1,33 @@
+package healeat.server.web.controller;
+
+import healeat.server.apiPayload.ApiResponse;
+import healeat.server.converter.ReviewConverter;
+import healeat.server.domain.Member;
+import healeat.server.domain.enums.SortBy;
+import healeat.server.domain.mapping.Review;
+import healeat.server.service.MemberService;
+import healeat.server.validation.annotation.CheckPage;
+import healeat.server.web.dto.MemberProfileResponseDto;
+import healeat.server.web.dto.StoreResonseDto;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/my-page")
+@RequiredArgsConstructor
+public class MyPageController {
+
+    private final MemberService memberService;
+
+    @GetMapping("/health-info")
+    @Operation(summary = "마이페이지 나의 건강정보 조회 API",
+            description = "마이페이지에서 나의 건강정보를 전체 조회할 수 있습니다.")
+    public ApiResponse<MemberProfileResponseDto.MyHealthProfileDto> getMyHealthInfo(
+            @AuthenticationPrincipal Member member) {
+
+        return ApiResponse.onSuccess(null);
+    }
+}

--- a/src/main/java/healeat/server/web/dto/MemberProfileResponseDto.java
+++ b/src/main/java/healeat/server/web/dto/MemberProfileResponseDto.java
@@ -1,7 +1,17 @@
 package healeat.server.web.dto;
 
+import healeat.server.domain.HealthInfoAnswer;
 import healeat.server.domain.Member;
+import healeat.server.domain.MemberHealQuestion;
+import healeat.server.domain.enums.Diet;
+import healeat.server.domain.enums.Question;
+import healeat.server.domain.enums.Vegetarian;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
 
 @Getter
 public class MemberProfileResponseDto {
@@ -15,4 +25,29 @@ public class MemberProfileResponseDto {
         response.profileImage = member.getProfileImageUrl();
         return response;
     }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class MyHealthProfileDto {
+
+        List<String> diseases; // List 가 Null 이면 나의 건강 목표에 질병관리 X
+        Vegetarian vegetarian;
+        Diet diet;
+
+        List<MyProfileQnaDto> qnas;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class MyProfileQnaDto {
+
+        Question question;
+        List<HealthInfoAnswer> healthInfoAnswers;
+    }
+
+
 }

--- a/src/main/java/healeat/server/web/dto/StoreResonseDto.java
+++ b/src/main/java/healeat/server/web/dto/StoreResonseDto.java
@@ -109,4 +109,40 @@ public class StoreResonseDto {
         String body;
         LocalDateTime createdAt;
     }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class HomeStorePreviewDto {
+
+        String storeName;
+
+        Float sickScore; // 환자 평점
+        Integer sickCount; // 환자 리뷰 수
+
+        Float vegetScore; // 베지테리언 평점
+        Integer vegetCount; // 베지테리언 리뷰 수
+
+        Float dietScore; // 다이어터 평점
+        Integer dietCount; // 다이어터 리뷰 수
+
+        List<String> images;
+
+        List<HomeReviewPreviewDto> reviews; // 디자인에 나와있는 것처럼 리뷰 2개
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class HomeReviewPreviewDto {
+
+        String name; // reviewer info 로 대체될 예정
+
+        Long reviewId;
+        Float totalScore;
+        String body;
+        LocalDateTime createdAt;
+    }
 }


### PR DESCRIPTION
## 📝 개요
[FEAT] Swagger 반영을 위한 DTO, Controller 틀 생성

## 🛠️ 작업 내용
<!-- 변경된 내용이나 추가된 기능을 아래에 나열해주세요. -->
- [x] 홈 화면 가게 리스트 조회, 가게 미리보기, 마이페이지(건강정보 조회) Controller 틀 구현
- [x] HealthPlan @AuthenticationPrincipal 추가

## 📌 관련 이슈
<!-- 연관된 이슈 번호를 연결해주세요. -->
- Resolved: #63 #64 

## ✅ 체크리스트
<!-- PR이 아래 조건을 충족했는지 확인해주세요. -->
- [ ] 관련된 모든 이슈가 PR에 명시되어 있습니다.
- [ ] 주요 변경 사항이 PR 설명에 포함되어 있습니다.
- [ ] 코드가 정상적으로 동작하며 테스트를 통과했습니다.
- [ ] 로컬 환경에서 예상대로 동작합니다.
- [ ] 필요한 문서가 업데이트되었습니다.
- [ ] 리뷰어가 참고할 추가 정보를 제공했습니다.

## 📷 스크린샷 (선택)
<!-- UI 변경 사항이 있다면 스크린샷을 첨부해주세요. -->

## 추가 내용
<!-- 리뷰어가 참고해야 할 추가 사항이 있다면 적어주세요. -->
